### PR TITLE
Handle special quote (#3)

### DIFF
--- a/app/javascript/omdb.js
+++ b/app/javascript/omdb.js
@@ -65,7 +65,7 @@ function requestOptions(title, season, episode, year) {
 		"apikey": API_KEY
 	};
 	if (title) {
-		options["t"] = title;
+		options["t"] = title.replace(/’/g, "'");
 	}
 	if (season) {
 		options["Season"] = season;


### PR DESCRIPTION
So, it seems that netflix use a special character for quotes and that make omdb not found the proper score.

Example: [`"To All the Boys I’ve Loved Before"`](https://www.netflix.com/title/80203147)